### PR TITLE
bugfix for return value when using filter option

### DIFF
--- a/security-alert-notifier.rb
+++ b/security-alert-notifier.rb
@@ -196,6 +196,12 @@ if $PROGRAM_NAME == __FILE__
           end
         end
       end
+
+      if vulnerable_repo_count == 0
+        puts "OK: No vulnerabilities"
+        exit 0
+      end
+
       puts "WARNING: #{total_vulnerabilities} vulnerabilities in #{vulnerable_repo_count} repos"
 
       github.vulnerable_repos.each do |repo|
@@ -211,11 +217,7 @@ if $PROGRAM_NAME == __FILE__
         end
       end
 
-      if vulnerable_repo_count == 0
-        exit 0
-      else
-        exit 1
-      end
+      exit 1
     else
       puts "OK: No vulnerabilities"
       exit 0

--- a/security-alert-notifier.rb
+++ b/security-alert-notifier.rb
@@ -211,7 +211,11 @@ if $PROGRAM_NAME == __FILE__
         end
       end
 
-      exit 1
+      if vulnerable_repo_count == 0
+        exit 0
+      else
+        exit 1
+      end
     else
       puts "OK: No vulnerabilities"
       exit 0


### PR DESCRIPTION
Bugfix for return value when using filter option
When i use the filter option to filter the result set, the return value is always 1. This change changed the value of vulnerable_repo_count and returned 0 when vulnerable_repo_count is 0. If vulnerable_repo_count is greater than 0, the return value is still 1.