### PR TITLE
Only list and count non-dismissed alerts

### DIFF
--- a/security-alert-notifier.rb
+++ b/security-alert-notifier.rb
@@ -54,15 +54,17 @@ class GitHub
   def build_repository_alerts(vulnerable_repos)
     vulnerable_repos.map do |repo|
       alerts = repo.dig("vulnerabilityAlerts", "nodes").map { |alert|
-        Alert.new(alert.dig("securityVulnerability", "package", "name"),
-          alert.dig("securityVulnerability", "vulnerableVersionRange"),
-          alert.dig("securityVulnerability", "firstPatchedVersion", "identifier"),
-          alert.dig("securityAdvisory", "summary"))
+        if alert.dig("dismissedAt").nil?
+          Alert.new(alert.dig("securityVulnerability", "package", "name"),
+            alert.dig("securityVulnerability", "vulnerableVersionRange"),
+            alert.dig("securityVulnerability", "firstPatchedVersion", "identifier"),
+            alert.dig("securityAdvisory", "summary"))
+        end
       }
 
       url = "https://github.com/#{repo["nameWithOwner"]}"
 
-      Repo.new(url, alerts)
+      Repo.new(url, alerts.compact)
     end
   end
 

--- a/security-alert-notifier_test.rb
+++ b/security-alert-notifier_test.rb
@@ -26,6 +26,30 @@ describe GitHub do
     end
   end
 
+  describe "when the repository has no dismissed alerts" do
+    it "is included in the list" do
+      github = GitHub.new
+      result = github.fetch_vulnerable_repos([repo_with_no_topics])
+      _(result.size).must_equal 1
+    end
+  end
+
+  describe "when the repository has only dismissed alerts" do
+    it "is not included in the list" do
+      github = GitHub.new
+      result = github.fetch_vulnerable_repos([repo_with_only_dismissed_alerts])
+      _(result.size).must_equal 0
+    end
+  end
+
+  describe "when the repository has some active alerts and some dismissed alerts" do
+    it "is included in the list" do
+      github = GitHub.new
+      result = github.fetch_vulnerable_repos([repo_with_active_and_dismissed_alerts])
+      _(result.size).must_equal 1
+    end
+  end
+
   describe "when a vulnerability alert does not have the attribute" do
     it "does not blow up" do
       github = GitHub.new
@@ -153,6 +177,24 @@ def valid_securityVulnerability
   }
 end
 
+def dismissed_securityVulnerability
+  {
+    "dismissedAt" => "2021-01-01T-15:50+00",
+    "securityVulnerability" => {
+      "package" => {
+        "name" => "Package Name"
+      },
+      "vulnerableVersionRange" => "A range of things",
+      "firstPatchedVersion" => {
+        "identifier" => "IDENTIFIER"
+      }
+    },
+    "securityAdvisory" => {
+      "summary" => "This is the summary"
+    }
+  }
+end
+
 def repo_without_alerts
   {
     "nameWithOwner" => "dxw/repo",
@@ -161,6 +203,30 @@ def repo_without_alerts
     },
     "vulnerabilityAlerts" => {
       "nodes" => []
+    }
+  }
+end
+
+def repo_with_only_dismissed_alerts
+  {
+    "nameWithOwner" => "dxw/repo",
+    "repositoryTopics" => {
+      "nodes" => []
+    },
+    "vulnerabilityAlerts" => {
+      "nodes" => [dismissed_securityVulnerability]
+    }
+  }
+end
+
+def repo_with_active_and_dismissed_alerts
+  {
+    "nameWithOwner" => "dxw/repo",
+    "repositoryTopics" => {
+      "nodes" => []
+    },
+    "vulnerabilityAlerts" => {
+      "nodes" => [valid_securityVulnerability, dismissed_securityVulnerability]
     }
   }
 end


### PR DESCRIPTION
Before: If a repo had some alerts that had already been dismissed, and some that hadn't, all would be listed and counted. If a repo only had dismissed alerts, it would not be listed, and those alerts would not be counted.

Now: Only active alerts are listed and counted. As before, if a repo only has dismissed alerts, it is not listed and those alerts are not counted.