### PR TITLE
Feature/filter before date

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ plugin](https://icinga.com/docs/icinga2/latest/doc/05-service-monitoring/#plugin
   vulnerabilities that haven't been dismissed will be displayed in the console.
   If there are vulnerabilties then the check will return a "Warning" status, else
   "OK".
+- Use the `--d` option with an ISO8601 date to only list alerts generated after that date
 
 ## Tests
 

--- a/security-alert-notifier.rb
+++ b/security-alert-notifier.rb
@@ -31,7 +31,7 @@ parser = OptionParser.new { |opts|
 class GitHub
   Result = Struct.new(:repos, :cursor, :more?)
   Repo = Struct.new(:url, :alerts)
-  Alert = Struct.new(:package_name, :affected_range, :fixed_in, :details)
+  Alert = Struct.new(:package_name, :affected_range, :fixed_in, :details, :created_at)
 
   BASE_URI = "https://api.github.com/graphql".freeze
 
@@ -58,7 +58,8 @@ class GitHub
           Alert.new(alert.dig("securityVulnerability", "package", "name"),
             alert.dig("securityVulnerability", "vulnerableVersionRange"),
             alert.dig("securityVulnerability", "firstPatchedVersion", "identifier"),
-            alert.dig("securityAdvisory", "summary"))
+            alert.dig("securityAdvisory", "summary"),
+            alert.dig("createdAt"))
         end
       }
 
@@ -121,6 +122,7 @@ class GitHub
               }
               vulnerabilityAlerts(first: 100) {
                 nodes {
+                  createdAt
                   dismissedAt
                   securityAdvisory {
                     summary
@@ -214,6 +216,7 @@ if $PROGRAM_NAME == __FILE__
 
           repo.alerts.each do |alert|
             puts "  #{alert.package_name} (#{alert.affected_range})"
+            puts "  Created at: #{alert.created_at}"
             puts "  Fixed in: #{alert.fixed_in}"
             puts "  Details: #{alert.details}"
             puts

--- a/security-alert-notifier_test.rb
+++ b/security-alert-notifier_test.rb
@@ -50,6 +50,22 @@ describe GitHub do
     end
   end
 
+  describe "when the repository has old alerts, and we have not filtered by date" do
+    it "is included in the list" do
+      github = GitHub.new
+      result = github.fetch_vulnerable_repos([repo_with_old_alerts])
+      _(result.size).must_equal 1
+    end
+  end
+
+  describe "when the repository has old alerts, and we have filtered by a date after that alert's creation" do
+    it "is not included in the list" do
+      github = GitHub.new("2021-01-01")
+      result = github.fetch_vulnerable_repos([repo_with_old_alerts])
+      _(result.size).must_equal 0
+    end
+  end
+
   describe "when a vulnerability alert does not have the attribute" do
     it "does not blow up" do
       github = GitHub.new
@@ -148,6 +164,7 @@ end
 
 def securityVulnerability_with_missing_attribute
   {
+    "createdAt" => "2021-01-01T-13:00+00",
     "securityVulnerability" => {
       "package" => {
         "name" => "Package Name"
@@ -162,6 +179,7 @@ end
 
 def valid_securityVulnerability
   {
+    "createdAt" => "2021-01-01T-13:00+00",
     "securityVulnerability" => {
       "package" => {
         "name" => "Package Name"
@@ -179,7 +197,26 @@ end
 
 def dismissed_securityVulnerability
   {
+    "createdAt" => "2021-01-01T-13:00+00",
     "dismissedAt" => "2021-01-01T-15:50+00",
+    "securityVulnerability" => {
+      "package" => {
+        "name" => "Package Name"
+      },
+      "vulnerableVersionRange" => "A range of things",
+      "firstPatchedVersion" => {
+        "identifier" => "IDENTIFIER"
+      }
+    },
+    "securityAdvisory" => {
+      "summary" => "This is the summary"
+    }
+  }
+end
+
+def old_securityVulnerability
+  {
+    "createdAt" => "2019-01-01T-13:00+00",
     "securityVulnerability" => {
       "package" => {
         "name" => "Package Name"
@@ -227,6 +264,18 @@ def repo_with_active_and_dismissed_alerts
     },
     "vulnerabilityAlerts" => {
       "nodes" => [valid_securityVulnerability, dismissed_securityVulnerability]
+    }
+  }
+end
+
+def repo_with_old_alerts
+  {
+    "nameWithOwner" => "dxw/repo",
+    "repositoryTopics" => {
+      "nodes" => []
+    },
+    "vulnerabilityAlerts" => {
+      "nodes" => [old_securityVulnerability]
     }
   }
 end


### PR DESCRIPTION
This PR adds the ability to only show alerts created after a specific date, using the `--d` option.

e.g. `./security-alert-notifier.rb --token [token] --organization dxw --d 2021-01-01` to only list alerts that were generated after 1st January 2021.

The default behaviour, without the `--d` option is as before, listing all open alerts.