### PR TITLE
Do not count fixed alerts

### DIFF
--- a/security-alert-notifier.rb
+++ b/security-alert-notifier.rb
@@ -44,7 +44,7 @@ class GitHub
       next if has_govpress_topic?(repo.dig("repositoryTopics", "nodes"))
       next if has_no_vulnerabilityAlerts?(repo.dig("vulnerabilityAlerts", "nodes"))
 
-      repo["vulnerabilityAlerts"]["nodes"].detect { |v| v["dismissedAt"].nil? }
+      repo["vulnerabilityAlerts"]["nodes"].detect { |v| v["dismissedAt"].nil? && v["fixedAt"].nil? }
     }
     return [] unless vulnerable_repos.any?
 
@@ -54,7 +54,7 @@ class GitHub
   def build_repository_alerts(vulnerable_repos)
     vulnerable_repos.map do |repo|
       alerts = repo.dig("vulnerabilityAlerts", "nodes").map { |alert|
-        if alert.dig("dismissedAt").nil?
+        if alert.dig("dismissedAt").nil? && alert.dig("fixedAt").nil?
           Alert.new(alert.dig("securityVulnerability", "package", "name"),
             alert.dig("securityVulnerability", "vulnerableVersionRange"),
             alert.dig("securityVulnerability", "firstPatchedVersion", "identifier"),
@@ -122,6 +122,7 @@ class GitHub
               vulnerabilityAlerts(first: 100) {
                 nodes {
                   dismissedAt
+                  fixedAt
                   securityAdvisory {
                     summary
                   }

--- a/security-alert-notifier_test.rb
+++ b/security-alert-notifier_test.rb
@@ -38,14 +38,30 @@ describe GitHub do
     it "is not included in the list" do
       github = GitHub.new
       result = github.fetch_vulnerable_repos([repo_with_only_dismissed_alerts])
-      _(result.size).must_equal 0
+      _(result).must_equal []
     end
   end
 
-  describe "when the repository has some active alerts and some dismissed alerts" do
+  describe "when the repository has only fixed alerts" do
+    it "is not included in the list" do
+      github = GitHub.new
+      result = github.fetch_vulnerable_repos([repo_with_only_fixed_alerts])
+      _(result).must_equal []
+    end
+  end
+
+  describe "when the repository has only fixed and dismissed alerts" do
+    it "is not included in the list" do
+      github = GitHub.new
+      result = github.fetch_vulnerable_repos([repo_with_only_fixed_and_dismissed_alerts])
+      _(result).must_equal []
+    end
+  end
+
+  describe "when the repository has some active alerts and some fixed and dismissed alerts" do
     it "is included in the list" do
       github = GitHub.new
-      result = github.fetch_vulnerable_repos([repo_with_active_and_dismissed_alerts])
+      result = github.fetch_vulnerable_repos([repo_with_active_and_fixed_and_dismissed_alerts])
       _(result.size).must_equal 1
     end
   end
@@ -195,6 +211,24 @@ def dismissed_securityVulnerability
   }
 end
 
+def fixed_securityVulnerability
+  {
+    "fixedAt" => "2021-01-01T-15:50+00",
+    "securityVulnerability" => {
+      "package" => {
+        "name" => "Package Name"
+      },
+      "vulnerableVersionRange" => "A range of things",
+      "firstPatchedVersion" => {
+        "identifier" => "IDENTIFIER"
+      }
+    },
+    "securityAdvisory" => {
+      "summary" => "This is the summary"
+    }
+  }
+end
+
 def repo_without_alerts
   {
     "nameWithOwner" => "dxw/repo",
@@ -219,14 +253,38 @@ def repo_with_only_dismissed_alerts
   }
 end
 
-def repo_with_active_and_dismissed_alerts
+def repo_with_only_fixed_alerts
   {
     "nameWithOwner" => "dxw/repo",
     "repositoryTopics" => {
       "nodes" => []
     },
     "vulnerabilityAlerts" => {
-      "nodes" => [valid_securityVulnerability, dismissed_securityVulnerability]
+      "nodes" => [fixed_securityVulnerability]
+    }
+  }
+end
+
+def repo_with_only_fixed_and_dismissed_alerts
+  {
+    "nameWithOwner" => "dxw/repo",
+    "repositoryTopics" => {
+      "nodes" => []
+    },
+    "vulnerabilityAlerts" => {
+      "nodes" => [fixed_securityVulnerability, dismissed_securityVulnerability]
+    }
+  }
+end
+
+def repo_with_active_and_fixed_and_dismissed_alerts
+  {
+    "nameWithOwner" => "dxw/repo",
+    "repositoryTopics" => {
+      "nodes" => []
+    },
+    "vulnerabilityAlerts" => {
+      "nodes" => [valid_securityVulnerability, fixed_securityVulnerability, dismissed_securityVulnerability]
     }
   }
 end


### PR DESCRIPTION
Before: when generating the report, the script did not count alerts that
had been dismissed, but did not account for the fact that alerts that
have been fixed are reported differently in the API (with a "fixedAt"
rather than a "dismissedAt" property). This resulted in it incorrectly
reporting alerts that had in fact been fixed.

Now: the script does not report alerts that have been fixed or
dismissed.