### PR TITLE
Add CLI option to write data to CSV file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ plugin](https://icinga.com/docs/icinga2/latest/doc/05-service-monitoring/#plugin
   with the `repo` scope
 - Run `security-alert-notifier.rb --token <access_token> --organization <organization_name>` and any
   vulnerabilities that haven't been dismissed will be displayed in the console.
-  If there are vulnerabilties then the check will return a "Warning" status, else
+  If there are vulnerabilities then the check will return a "Warning" status, else
   "OK".
 
 ## Tests


### PR DESCRIPTION
This commit adds a new command line switch: --csv FILE which causes the script to write data to a CSV file rather than printing to STDOUT.

This is useful when dealing with a larger number of vulerabilities in an organisation.

The built in Ruby Csv class is used to handle formatting and escaping CSV data, and quotes are always used around cell data. However, some strings may not be parsed well by spreadsheets, for example "= 9.1.2" may still be read as a forumla.