### PR TITLE
Chore/add scripts to rule them all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,9 @@ on:
   - pull_request
 
 jobs:
-  lint:
+  lint-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
       - uses: ruby/setup-ruby@v1
-      - run: gem install bundler
-      - run: bundle install
-      - run: bundle exec standardrb
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: ruby/setup-ruby@v1
-      - run: ruby ./security-alert-notifier_test.rb
+      - run: ./script/test

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew "rbenv"
+brew "shellcheck"

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ To run the standard lint ([`standardrb`](https://github.com/testdouble/standardr
 ```shell
 ./script/test
 ```
+
+For dxw employees, please note that this code is also used downstream in our
+Chef configuration, and any changes you merge in here also need to be reflected there.
+If this isn't clear to you, please speak to a colleague from Ops.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Then run the relevant script to setup your environment and install dependencies:
   If there are vulnerabilities then the check will return a "Warning" status, else
   "OK".
 
+If you prefer to receive the results as a CSV file, rather than as text to STDOUT, please run:
+
+```shell
+security-alert-notifier.rb --token <access_token> --organization <organization_name> --csv <filename>
+```
+
 ## Contributing to this repository
 
 To run the standard lint ([`standardrb`](https://github.com/testdouble/standardrb)) and unit tests for this code, run:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,22 @@ GitHub organization, using the GitHub API (v4). Designed to be used as an
 [Icinga
 plugin](https://icinga.com/docs/icinga2/latest/doc/05-service-monitoring/#plugin-api).
 
+## Getting started
+
+This repository implements the [scripts to rule them all](https://github.com/github/scripts-to-rule-them-all) pattern.
+
+To use this code, start by cloning the repository:
+
+```shell
+$ git clone git@github.com:dxw/security-alert-notifier.git
+```
+
+Then run the relevant script to setup your environment and install dependencies:
+
+```shell
+./script/setup
+```
+
 ## Usage
 
 - Obtain a [personal GitHub OAuth
@@ -15,10 +31,10 @@ plugin](https://icinga.com/docs/icinga2/latest/doc/05-service-monitoring/#plugin
   If there are vulnerabilities then the check will return a "Warning" status, else
   "OK".
 
-## Tests
+## Contributing to this repository
 
-Basic tests can be run with
+To run the standard lint ([`standardrb`](https://github.com/testdouble/standardrb)) and unit tests for this code, run:
 
-```bash
-ruby security-alert-notifier_test.rb
+```shell
+./script/test
 ```

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# script/bootstrap: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -f .gitmodules ]; then
+  echo "==> Updating Git submodules..."
+  git submodule update --init
+fi
+
+if [ -z "$CI" ]; then
+  if [ -f Brewfile ] && [ "$(uname -s)" = "Darwin" ]; then
+    if ! brew bundle check >/dev/null 2>&1; then
+      echo "==> Installing Homebrew dependencies..."
+      brew bundle install --verbose
+    fi
+  fi
+
+  if [ -f .ruby-version ]; then
+    eval "$(rbenv init -)"
+
+    if [ -z "$(rbenv version-name 2>/dev/null)" ]; then
+      echo "==> Installing Ruby..."
+      rbenv install --skip-existing
+      rbenv rehash
+    fi
+  fi
+fi
+
+if ! command -v bundle >/dev/null 2>&1; then
+  echo "==> Installing Bundler..."
+  gem install bundler
+
+  if [ -z "$CI" ]; then
+    rbenv rehash
+  fi
+fi
+
+if ! bundle check >/dev/null 2>&1; then
+  echo "==> Installing Ruby dependencies..."
+  bundle install --path vendor/bundle
+fi

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# script/setup: Set up the application for the first time after cloning, or set
+#               it back to the initial unused state.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -d vendor/bundle ]; then
+  echo "==> Cleaning installed Ruby dependencies..."
+  git clean -x --force -- vendor/bundle
+fi
+
+echo "==> Bootstrapping..."
+script/bootstrap

--- a/script/test
+++ b/script/test
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# script/test: Run the test suite for the application.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -n "$DEBUG" ]; then
+  set -x
+fi
+
+echo "==> Updating..."
+script/update
+
+echo "==> Running ShellCheck..."
+shellcheck script/*
+
+if [ -n "$CI" ]; then
+  echo "==> Linting Ruby..."
+  bundle exec standardrb
+else
+  echo "==> Linting Ruby in fix mode..."
+  bundle exec standardrb --fix
+fi
+
+echo "==> Running the tests..."
+ruby security-alert-notifier_test.rb

--- a/script/update
+++ b/script/update
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# script/update: Update the application to run for its current checkout.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Bootstrapping..."
+script/bootstrap


### PR DESCRIPTION
* Add scripts-to-rule-them-all pattern to this repository. Note that a `.ruby-version` file had already been committed.
* GH actions now uses `script/test` rather than hard-coding each command.
* Update README.
* Add note to README about the presence of a downstream repo (dxw only).
* Document new `--csv` CLI switch.