### PR TITLE
Feature/specifiy topics on command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,56 @@
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
 .env
 
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*

--- a/security-alert-notifier_test.rb
+++ b/security-alert-notifier_test.rb
@@ -4,23 +4,39 @@ require_relative "security-alert-notifier"
 describe GitHub do
   describe "when the repository has no topics" do
     it "is included in the list" do
-      github = GitHub.new([])
+      github = GitHub.new([], [])
       result = github.fetch_vulnerable_repos([repo_with_no_topics])
       _(result.size).must_equal 1
     end
   end
 
-  describe "when the repository has topics but none are 'govpress'" do
+  describe "when the repository has topics but none are excluded" do
     it "is included in the list" do
-      github = GitHub.new(["govpress"])
+      github = GitHub.new([], ["govpress"])
       result = github.fetch_vulnerable_repos([repo_with_topics])
       _(result.size).must_equal 1
     end
   end
 
-  describe "when the repository has topics and one is 'govpress'" do
+  describe "when the repository has topics and one is included" do
     it "is not included in the list" do
-      github = GitHub.new(["govpress"])
+      github = GitHub.new(["govpress"], [])
+      result = github.fetch_vulnerable_repos([repo_with_govpress_topic])
+      _(result.size).must_equal 1
+    end
+  end
+
+  describe "when the repository has topics but none are included" do
+    it "is included in the list" do
+      github = GitHub.new(["govpress"], [])
+      result = github.fetch_vulnerable_repos([repo_with_topics])
+      _(result).must_equal []
+    end
+  end
+
+  describe "when the repository has topics and one is excluded" do
+    it "is not included in the list" do
+      github = GitHub.new([], ["govpress"])
       result = github.fetch_vulnerable_repos([repo_with_govpress_topic])
       _(result).must_equal []
     end
@@ -28,7 +44,7 @@ describe GitHub do
 
   describe "when the repository has no dismissed alerts" do
     it "is included in the list" do
-      github = GitHub.new([])
+      github = GitHub.new([], [])
       result = github.fetch_vulnerable_repos([repo_with_no_topics])
       _(result.size).must_equal 1
     end
@@ -36,7 +52,7 @@ describe GitHub do
 
   describe "when the repository has only dismissed alerts" do
     it "is not included in the list" do
-      github = GitHub.new([])
+      github = GitHub.new([], [])
       result = github.fetch_vulnerable_repos([repo_with_only_dismissed_alerts])
       _(result).must_equal []
     end
@@ -44,7 +60,7 @@ describe GitHub do
 
   describe "when the repository has only fixed alerts" do
     it "is not included in the list" do
-      github = GitHub.new([])
+      github = GitHub.new([], [])
       result = github.fetch_vulnerable_repos([repo_with_only_fixed_alerts])
       _(result).must_equal []
     end
@@ -52,7 +68,7 @@ describe GitHub do
 
   describe "when the repository has only fixed and dismissed alerts" do
     it "is not included in the list" do
-      github = GitHub.new([])
+      github = GitHub.new([], [])
       result = github.fetch_vulnerable_repos([repo_with_only_fixed_and_dismissed_alerts])
       _(result).must_equal []
     end
@@ -60,7 +76,7 @@ describe GitHub do
 
   describe "when the repository has some active alerts and some fixed and dismissed alerts" do
     it "is included in the list" do
-      github = GitHub.new([])
+      github = GitHub.new([], [])
       result = github.fetch_vulnerable_repos([repo_with_active_and_fixed_and_dismissed_alerts])
       _(result.size).must_equal 1
     end
@@ -68,14 +84,14 @@ describe GitHub do
 
   describe "when a vulnerability alert does not have the attribute" do
     it "does not blow up" do
-      github = GitHub.new([])
+      github = GitHub.new([], [])
       vulnerable_repos = [{"vulnerabilityAlerts" => {"nodes" => [securityVulnerability_with_missing_attribute]}}]
       result = github.build_repository_alerts(vulnerable_repos)
       _(result.first).must_be_instance_of GitHub::Repo
     end
 
     it "return nil in the alert for the missin attribute" do
-      github = GitHub.new([])
+      github = GitHub.new([], [])
       vulnerable_repos = [{"vulnerabilityAlerts" => {"nodes" => [securityVulnerability_with_missing_attribute]}}]
       result = github.build_repository_alerts(vulnerable_repos).first.alerts.first
       _(result.details).must_be_nil
@@ -84,7 +100,7 @@ describe GitHub do
 
   describe "when the vulnerability is well formed" do
     it "a valid alert" do
-      github = GitHub.new([])
+      github = GitHub.new([], [])
       vulnerable_repos = [{"vulnerabilityAlerts" => {"nodes" => [valid_securityVulnerability]}}]
       result = github.build_repository_alerts(vulnerable_repos).first.alerts.first
       _(result.created_at).must_equal "2020-12-19T-13:13+00"
@@ -98,7 +114,7 @@ describe GitHub do
 
   describe "when there are no repos" do
     it "returns an empty array" do
-      github = GitHub.new([])
+      github = GitHub.new([], [])
       result = github.fetch_vulnerable_repos([])
       _(result).must_equal []
     end
@@ -106,7 +122,7 @@ describe GitHub do
 
   describe "when there are no repos with alerts" do
     it "returns an empty array" do
-      github = GitHub.new([])
+      github = GitHub.new([], [])
       result = github.fetch_vulnerable_repos([repo_without_alerts])
       _(result).must_equal []
     end

--- a/security-alert-notifier_test.rb
+++ b/security-alert-notifier_test.rb
@@ -4,7 +4,7 @@ require_relative "security-alert-notifier"
 describe GitHub do
   describe "when the repository has no topics" do
     it "is included in the list" do
-      github = GitHub.new
+      github = GitHub.new([])
       result = github.fetch_vulnerable_repos([repo_with_no_topics])
       _(result.size).must_equal 1
     end
@@ -12,7 +12,7 @@ describe GitHub do
 
   describe "when the repository has topics but none are 'govpress'" do
     it "is included in the list" do
-      github = GitHub.new
+      github = GitHub.new(["govpress"])
       result = github.fetch_vulnerable_repos([repo_with_topics])
       _(result.size).must_equal 1
     end
@@ -20,7 +20,7 @@ describe GitHub do
 
   describe "when the repository has topics and one is 'govpress'" do
     it "is not included in the list" do
-      github = GitHub.new
+      github = GitHub.new(["govpress"])
       result = github.fetch_vulnerable_repos([repo_with_govpress_topic])
       _(result).must_equal []
     end
@@ -28,7 +28,7 @@ describe GitHub do
 
   describe "when the repository has no dismissed alerts" do
     it "is included in the list" do
-      github = GitHub.new
+      github = GitHub.new([])
       result = github.fetch_vulnerable_repos([repo_with_no_topics])
       _(result.size).must_equal 1
     end
@@ -36,7 +36,7 @@ describe GitHub do
 
   describe "when the repository has only dismissed alerts" do
     it "is not included in the list" do
-      github = GitHub.new
+      github = GitHub.new([])
       result = github.fetch_vulnerable_repos([repo_with_only_dismissed_alerts])
       _(result).must_equal []
     end
@@ -44,7 +44,7 @@ describe GitHub do
 
   describe "when the repository has only fixed alerts" do
     it "is not included in the list" do
-      github = GitHub.new
+      github = GitHub.new([])
       result = github.fetch_vulnerable_repos([repo_with_only_fixed_alerts])
       _(result).must_equal []
     end
@@ -52,7 +52,7 @@ describe GitHub do
 
   describe "when the repository has only fixed and dismissed alerts" do
     it "is not included in the list" do
-      github = GitHub.new
+      github = GitHub.new([])
       result = github.fetch_vulnerable_repos([repo_with_only_fixed_and_dismissed_alerts])
       _(result).must_equal []
     end
@@ -60,7 +60,7 @@ describe GitHub do
 
   describe "when the repository has some active alerts and some fixed and dismissed alerts" do
     it "is included in the list" do
-      github = GitHub.new
+      github = GitHub.new([])
       result = github.fetch_vulnerable_repos([repo_with_active_and_fixed_and_dismissed_alerts])
       _(result.size).must_equal 1
     end
@@ -68,14 +68,14 @@ describe GitHub do
 
   describe "when a vulnerability alert does not have the attribute" do
     it "does not blow up" do
-      github = GitHub.new
+      github = GitHub.new([])
       vulnerable_repos = [{"vulnerabilityAlerts" => {"nodes" => [securityVulnerability_with_missing_attribute]}}]
       result = github.build_repository_alerts(vulnerable_repos)
       _(result.first).must_be_instance_of GitHub::Repo
     end
 
     it "return nil in the alert for the missin attribute" do
-      github = GitHub.new
+      github = GitHub.new([])
       vulnerable_repos = [{"vulnerabilityAlerts" => {"nodes" => [securityVulnerability_with_missing_attribute]}}]
       result = github.build_repository_alerts(vulnerable_repos).first.alerts.first
       _(result.details).must_be_nil
@@ -84,7 +84,7 @@ describe GitHub do
 
   describe "when the vulnerability is well formed" do
     it "a valid alert" do
-      github = GitHub.new
+      github = GitHub.new([])
       vulnerable_repos = [{"vulnerabilityAlerts" => {"nodes" => [valid_securityVulnerability]}}]
       result = github.build_repository_alerts(vulnerable_repos).first.alerts.first
       _(result.created_at).must_equal "2020-12-19T-13:13+00"
@@ -98,7 +98,7 @@ describe GitHub do
 
   describe "when there are no repos" do
     it "returns an empty array" do
-      github = GitHub.new
+      github = GitHub.new([])
       result = github.fetch_vulnerable_repos([])
       _(result).must_equal []
     end
@@ -106,7 +106,7 @@ describe GitHub do
 
   describe "when there are no repos with alerts" do
     it "returns an empty array" do
-      github = GitHub.new
+      github = GitHub.new([])
       result = github.fetch_vulnerable_repos([repo_without_alerts])
       _(result).must_equal []
     end


### PR DESCRIPTION
Closes #22 

This PR:

1. Adds a commit to add a `.gitignore` file.
1. Adds two commits which allow the user to specify repos to include / exclude from the command line.

Currently, the script is hard-coded to filter out all repos that have the topic `govpress`. This means that GovPress colleagues need to edit the code before running the main script, and also that the script is less helpful to people outside of dxw, even though the repo is public.

The intention of the PR is that user will be able to run this code with:

```shell
./security-alert-notifier --organization dxw --exclude govpress
```

to recreate the default behaviour in `main`, or:

```shell
./security-alert-notifier --organization dxw --include govpress
```

for colleagues in GovPress.

More than one topic can be specified at a time, e.g.:

```shell
./security-alert-notifier --organization dxw --include govpress,tech-ops
```