### PR TITLE
Report severity and time to SLA breach

### DIFF
--- a/security-alert-notifier.rb
+++ b/security-alert-notifier.rb
@@ -1,10 +1,15 @@
 #!/usr/bin/env ruby
 
 require "csv"
+require "date"
 require "optparse"
 require "net/http"
 require "open-uri"
 require "json"
+
+# We aim to close vulnerability alerts within SLA_IN_DAYS days. In this script,
+# we count all calendar days, including weekends and bank holidays.
+SLA_IN_DAYS = 14
 
 options = {}
 
@@ -36,7 +41,7 @@ parser = OptionParser.new { |opts|
 class GitHub
   Result = Struct.new(:repos, :cursor, :more?)
   Repo = Struct.new(:url, :alerts)
-  Alert = Struct.new(:package_name, :affected_range, :severity, :fixed_in, :details)
+  Alert = Struct.new(:package_name, :affected_range, :severity, :created_at, :fixed_in, :details)
 
   BASE_URI = "https://api.github.com/graphql".freeze
 
@@ -63,6 +68,7 @@ class GitHub
           Alert.new(alert.dig("securityVulnerability", "package", "name"),
             alert.dig("securityVulnerability", "vulnerableVersionRange"),
             alert.dig("securityVulnerability", "severity"),
+            alert.dig("createdAt"),
             alert.dig("securityVulnerability", "firstPatchedVersion", "identifier"),
             alert.dig("securityAdvisory", "summary"))
         end
@@ -127,6 +133,7 @@ class GitHub
               }
               vulnerabilityAlerts(first: 100) {
                 nodes {
+                  createdAt
                   dismissedAt
                   fixedAt
                   securityAdvisory {
@@ -216,16 +223,19 @@ if $PROGRAM_NAME == __FILE__
 
       puts "WARNING: #{total_vulnerabilities} vulnerabilities in #{vulnerable_repo_count} repos"
 
-      csv_data = [["Repository", "Package", "Severity", "Affected range", "Fixed in", "Details"]]
+      csv_data = [["Repository", "Package", "Severity", "Calendar days to SLA breach", "Affected range", "Fixed in", "Details"]]
 
       github.vulnerable_repos.each do |repo|
         if options[:filter].nil? || repo.url =~ /#{options[:filter]}/
           puts repo.url if options[:csv].nil?
 
           repo.alerts.each do |alert|
+            time_to_sla_breach = SLA_IN_DAYS - (Date.today - Date.parse(alert.created_at)).to_i
+
             if options[:csv].nil?
               puts "  #{alert.package_name} (#{alert.affected_range})"
               puts "  Severity: #{alert.severity.capitalize}"
+              puts "  SLA breach in: #{time_to_sla_breach} calendar days"
               puts "  Fixed in: #{alert.fixed_in}"
               puts "  Details: #{alert.details}"
               puts
@@ -233,6 +243,7 @@ if $PROGRAM_NAME == __FILE__
               csv_data.append([repo.url,
                 alert.package_name,
                 alert.severity.capitalize,
+                time_to_sla_breach,
                 alert.affected_range,
                 alert.fixed_in,
                 alert.details])

--- a/security-alert-notifier_test.rb
+++ b/security-alert-notifier_test.rb
@@ -87,6 +87,7 @@ describe GitHub do
       github = GitHub.new
       vulnerable_repos = [{"vulnerabilityAlerts" => {"nodes" => [valid_securityVulnerability]}}]
       result = github.build_repository_alerts(vulnerable_repos).first.alerts.first
+      _(result.created_at).must_equal "2020-12-19T-13:13+00"
       _(result.package_name).must_equal "Package Name"
       _(result.severity).must_equal "CRITICAL"
       _(result.affected_range).must_equal "A range of things"
@@ -181,6 +182,7 @@ end
 
 def valid_securityVulnerability
   {
+    "createdAt" => "2020-12-19T-13:13+00",
     "securityVulnerability" => {
       "package" => {
         "name" => "Package Name"
@@ -199,6 +201,7 @@ end
 
 def dismissed_securityVulnerability
   {
+    "createdAt" => "2020-12-21T-13:17+00",
     "dismissedAt" => "2021-01-01T-15:50+00",
     "securityVulnerability" => {
       "package" => {
@@ -218,6 +221,7 @@ end
 
 def fixed_securityVulnerability
   {
+    "createdAt" => "2020-12-20T-14:31+00",
     "fixedAt" => "2021-01-01T-15:50+00",
     "securityVulnerability" => {
       "package" => {

--- a/security-alert-notifier_test.rb
+++ b/security-alert-notifier_test.rb
@@ -88,6 +88,7 @@ describe GitHub do
       vulnerable_repos = [{"vulnerabilityAlerts" => {"nodes" => [valid_securityVulnerability]}}]
       result = github.build_repository_alerts(vulnerable_repos).first.alerts.first
       _(result.package_name).must_equal "Package Name"
+      _(result.severity).must_equal "CRITICAL"
       _(result.affected_range).must_equal "A range of things"
       _(result.fixed_in).must_equal "IDENTIFIER"
       _(result.details).must_equal "This is the summary"
@@ -169,6 +170,7 @@ def securityVulnerability_with_missing_attribute
       "package" => {
         "name" => "Package Name"
       },
+      "severity" => "HIGH",
       "vulnerableVersionRange" => "A range of things",
       "firstPatchedVersion" => {
         "identifier" => "IDENTIFIER"
@@ -183,6 +185,7 @@ def valid_securityVulnerability
       "package" => {
         "name" => "Package Name"
       },
+      "severity" => "CRITICAL",
       "vulnerableVersionRange" => "A range of things",
       "firstPatchedVersion" => {
         "identifier" => "IDENTIFIER"
@@ -201,6 +204,7 @@ def dismissed_securityVulnerability
       "package" => {
         "name" => "Package Name"
       },
+      "severity" => "LOW",
       "vulnerableVersionRange" => "A range of things",
       "firstPatchedVersion" => {
         "identifier" => "IDENTIFIER"
@@ -219,6 +223,7 @@ def fixed_securityVulnerability
       "package" => {
         "name" => "Package Name"
       },
+      "severity" => "MODERATE",
       "vulnerableVersionRange" => "A range of things",
       "firstPatchedVersion" => {
         "identifier" => "IDENTIFIER"


### PR DESCRIPTION
This PR adds new information to the security alert reports: 

* [Severity](https://docs.github.com/en/graphql/reference/enums#securityadvisoryseverity)
* Time to SLA breach

Our SLA is currently 14 days, however this is currently calculated in the PR as calendar days rather than working days.

The output now looks like this in STDOUT:

```plaintext
WARNING: 2 vulnerabilities in 2 repos
https://github.com/...
  package (< x.y.z)
  Severity: High
  SLA breach in: 14 calendar days
  Fixed in: x.y.z
  Details: ...

https://github.com/...
  package (< x.y.z)
  Severity: High
  SLA breach in: 10 calendar days
  Fixed in: x.y.z
  Details: ...
```

And the CSV output looks like this:

```csv
"Repository","Package","Severity","Time to SLA breach","Affected range","Fixed in","Details"
"https://github.com/...","package","High","14","< x.y.z","x.y.x","..."
"https://github.com/...","package","High","10","< x.y.z","x.y.z","..."
```